### PR TITLE
Feat/optional ingress host

### DIFF
--- a/stable/chart-ad/Chart.yaml
+++ b/stable/chart-ad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: chart-ad
-version: 0.0.14
+version: 0.0.15
 home: https://archdaily.com/
 maintainers:
 - name: Ops Team

--- a/stable/chart-ad/templates/ingress.yaml
+++ b/stable/chart-ad/templates/ingress.yaml
@@ -3,7 +3,7 @@
 {{- $imageTag := .Values.image.tag -}}
 {{- $imageEnv := .Values.image.env -}}
 {{- $imageBranch := .Values.image.branch -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ printf "%s" .Release.Name | trunc 63 }}

--- a/stable/chart-ad/templates/ingress.yaml
+++ b/stable/chart-ad/templates/ingress.yaml
@@ -19,8 +19,7 @@ metadata:
 spec:
   rules:
   {{- range $host := .Values.ingress.hosts }}
-    - host: {{ tpl $host $ }}
-      http:
+    - http:
         paths:
         {{- range $item := $.Values.ingress.paths.proxy_pass }}
         - backend:
@@ -34,5 +33,8 @@ spec:
             servicePort: {{ .servicePort }}
           path: {{ .path }}
         {{- end -}}
+    {{- if not (empty $host) }}
+      host: {{ tpl $host $ }}
+    {{- end }}
   {{- end -}}
 {{- end }}


### PR DESCRIPTION
```yaml
# Source: chart-ad/templates/ingress.yaml
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  name: test
  labels:
    app: test
    version: 0.0.15
    release: test
    env: production
spec:
  rules:
    - http:
        paths:
        - backend:
            serviceName: test
            servicePort: 80
          path: /
```